### PR TITLE
fixed is_file() call with null in PHP 8.1

### DIFF
--- a/src/Attestation/Format/FormatBase.php
+++ b/src/Attestation/Format/FormatBase.php
@@ -27,7 +27,7 @@ abstract class FormatBase {
      */
     public function __destruct() {
         // delete X.509 chain certificate file after use
-        if (\is_file($this->_x5c_tempFile)) {
+        if ($this->_x5c_tempFile && \is_file($this->_x5c_tempFile)) {
             \unlink($this->_x5c_tempFile);
         }
     }
@@ -37,7 +37,7 @@ abstract class FormatBase {
      * @return string|null
      */
     public function getCertificateChain() {
-        if (\is_file($this->_x5c_tempFile)) {
+        if ($this->_x5c_tempFile && \is_file($this->_x5c_tempFile)) {
             return \file_get_contents($this->_x5c_tempFile);
         }
         return null;


### PR DESCRIPTION
Hi!

Just a small fix for PHP 8.1.
Calling is_file() with null will throw an error in PHP 8.1, so i added a check for this.
