### PR TITLE
Handle Atos CardOS FIDO2 correct

### DIFF
--- a/src/WebAuthn.php
+++ b/src/WebAuthn.php
@@ -534,9 +534,12 @@ class WebAuthn {
                         $certContent .= \str_repeat('-', \mb_strlen($description)) . "\n";
 
                         foreach ($attestationRootCertificates as $attestationRootCertificate) {
+                            $attestationRootCertificate = \trim($attestationRootCertificate);
                             $count++;
                             $certContent .= "\n-----BEGIN CERTIFICATE-----\n";
-                            $certContent .= \chunk_split(\trim($attestationRootCertificate), 64, "\n");
+                            $certContent .= \strstr($attestationRootCertificate, "\n") !== false ?
+                                $attestationRootCertificate . "\n" :
+                                \chunk_split($attestationRootCertificate, 64, "\n");
                             $certContent .= "-----END CERTIFICATE-----\n";
                         }
 


### PR DESCRIPTION
Unfortunately, the certificate for Atos CardOS Fido2 already contains line breaks. Therefore, we do not need to apply split_chunk here.

Excerpt from https://mds.fidoalliance.org/
````
"attestationRootCertificates": [
          "MIIBsjCCAVigAwIBAgIJAKIFntEOQ1tXMAoGCCqGSM49BAMCMFQxCzAJBgNVBAYT\nAkdFMQ0wCwYDVQQKDARBdG9zMSIwIAYDVQQLDBlBdXRoZW50aWNhdG9yIEF0dGVz\ndGF0aW9uMRIwEAYDVQQDDAlBdG9zIHJvb3QwHhcNMjAwOTA5MDYxNDU4WhcNMzAw\nOTA3MDYxNDU4WjBUMQswCQYDVQQGEwJHRTENMAsGA1UECgwEQXRvczEiMCAGA1UE\nCwwZQXV0aGVudGljYXRvciBBdHRlc3RhdGlvbjESMBAGA1UEAwwJQXRvcyByb290\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEpKR0f6Vdq0PYXxH7JVMkGxNoM4Xo\nHFuQ+e7qf+04P4J2GGS9vXFLVQZ5coFnRPfCflDCLkzafM3QEdcYCVoyPKMTMBEw\nDwYDVR0TAQH/BAUwAwEB/zAKBggqhkjOPQQDAgNIADBFAiEAzXpow3/4yOXNbALo\ndMv5KIornn5wRRI36YQpv3Wbh00CIEy14Sy7LrlgJSZTG0Md5wjQbyoVTfU/2oZy\np9EnplDL"
        ],
````