### PR TITLE
Fix JsonSerializable return type (PHP 8.1)

### DIFF
--- a/src/Binary/ByteBuffer.php
+++ b/src/Binary/ByteBuffer.php
@@ -213,6 +213,7 @@ class ByteBuffer implements \JsonSerializable, \Serializable {
      * return binary data in RFC 1342-Like serialized string
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize() {
         if (ByteBuffer::$useBase64UrlEncoding) {
             return self::_base64url_encode($this->_data);


### PR DESCRIPTION
```
During inheritance of JsonSerializable: Uncaught ErrorException: Return type of lbuchs\WebAuthn\Binary\ByteBuffer::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice
```

Fix https://github.com/lbuchs/WebAuthn/issues/52 without breaking changes (it was not fixed yet)