### PR TITLE
Return isBackupEligible & isBackup in processCreate

### DIFF
--- a/src/Attestation/AuthenticatorData.php
+++ b/src/Attestation/AuthenticatorData.php
@@ -189,6 +189,24 @@ class AuthenticatorData {
         return $this->_flags->userVerified;
     }
 
+    /**
+     * returns true if the backup is eligible
+     * @return boolean
+     */
+    public function getIsBackupEligible()
+    {
+        return $this->_flags->isBackupEligible;
+    }
+
+    /**
+     * returns true if the current credential is backed up
+     * @return boolean
+     */
+    public function getIsBackup()
+    {
+        return $this->_flags->isBackup;
+    }
+
     // -----------------------------------------------
     // PRIVATE
     // -----------------------------------------------
@@ -259,6 +277,8 @@ class AuthenticatorData {
         // named flags
         $flags->userPresent = $flags->bit_0;
         $flags->userVerified = $flags->bit_2;
+        $flags->isBackupEligible = $flags->bit_3;
+        $flags->isBackup = $flags->bit_4;
         $flags->attestedDataIncluded = $flags->bit_6;
         $flags->extensionDataIncluded = $flags->bit_7;
         return $flags;

--- a/src/WebAuthn.php
+++ b/src/WebAuthn.php
@@ -397,6 +397,8 @@ class WebAuthn {
         $data->rootValid = $rootValid;
         $data->userPresent = $userPresent;
         $data->userVerified = $userVerified;
+    	$data->isBackupEligible = $attestationObject->getAuthenticatorData()->getIsBackupEligible();
+        $data->isBackedUp = $attestationObject->getAuthenticatorData()->getIsBackup();
         return $data;
     }
 


### PR DESCRIPTION
Retrieve the `isBackupEligible` and `isBackup` flags from `authData`. 
These two fields provide informative data to display in the passkey list within the application.

References to:
- https://github.com/MasterKale/SimpleWebAuthn/blob/a169def3c663cb671cdc6bc6e00a4993944a61ae/packages/server/src/helpers/parseAuthenticatorData.ts#L30