### PR TITLE
#94 Check for known android key hashes

### DIFF
--- a/src/WebAuthn.php
+++ b/src/WebAuthn.php
@@ -621,7 +621,7 @@ class WebAuthn {
      * @throws WebAuthnException
      */
     private function _checkOrigin($origin) {
-        if (str_starts_with('android:apk-key-hash:', $origin)) {
+        if (str_starts_with($origin, 'android:apk-key-hash:')) {
             return $this->_checkAndroidKeyHashes($origin);
         }
 


### PR DESCRIPTION
If the origin starts with `android:apk-key-hash:`, it will check for the allowed/known android key hashes instead of checking the expected origin URL for the RP ID