### PR TITLE
Update server.php to set Signature counter to 0

### DIFF
--- a/_test/server.php
+++ b/_test/server.php
@@ -214,7 +214,8 @@ try {
         $data->userId = $userId;
         $data->userName = $userName;
         $data->userDisplayName = $userDisplayName;
-
+        //set Null to 0
+        $data->signatureCounter ??= 0;
         if (!isset($_SESSION['registrations']) || !array_key_exists('registrations', $_SESSION) || !is_array($_SESSION['registrations'])) {
             $_SESSION['registrations'] = [];
         }


### PR DESCRIPTION
Was getting failures on apple passkeys when using touchID as the SigCounter remains at 0. hint found via apple passkey issue on stack overflow. 
 https://stackoverflow.com/questions/78776653/passkey-counter-always-0-macos