### PR TITLE
openssl ed25519 fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Availability of built-in passkeys that automatically synchronize to all of a use
 ## Requirements
 * PHP >= 8.0 with [OpenSSL](http://php.net/manual/en/book.openssl.php) and [Multibyte String](https://www.php.net/manual/en/book.mbstring.php)
 * Browser with [WebAuthn support](https://caniuse.com/webauthn) (Firefox 60+, Chrome 67+, Edge 18+, Safari 13+)
-* PHP [Sodium](https://www.php.net/manual/en/book.sodium.php) (or [Sodium Compat](https://github.com/paragonie/sodium_compat) ) for [Ed25519](https://en.wikipedia.org/wiki/EdDSA#Ed25519) support
+* PHP [Sodium](https://www.php.net/manual/en/book.sodium.php) (or [Sodium Compat](https://github.com/paragonie/sodium_compat)) for [Ed25519](https://en.wikipedia.org/wiki/EdDSA#Ed25519) support, or OpenSSL (PHP ≥ 8.4) with native Ed25519 support
 
 ## Infos about WebAuthn
 * [Wikipedia](https://en.wikipedia.org/wiki/WebAuthn)

--- a/src/WebAuthn.php
+++ b/src/WebAuthn.php
@@ -186,7 +186,7 @@ class WebAuthn {
         // supported algorithms
         $args->publicKey->pubKeyCredParams = [];
 
-        if (function_exists('sodium_crypto_sign_verify_detached') || \in_array('ed25519', \openssl_get_curve_names(), true)) {
+        if (function_exists('sodium_crypto_sign_verify_detached') || defined('OPENSSL_KEYTYPE_ED25519')) {
             $tmp = new \stdClass();
             $tmp->type = 'public-key';
             $tmp->alg = -8; // EdDSA
@@ -677,7 +677,7 @@ class WebAuthn {
     private function _verifySignature($dataToVerify, $signature, $credentialPublicKey) {
 
         // Use Sodium to verify EdDSA 25519 as its not yet supported by openssl
-        if (\function_exists('sodium_crypto_sign_verify_detached') && !\in_array('ed25519', \openssl_get_curve_names(), true)) {
+        if (\function_exists('sodium_crypto_sign_verify_detached') && !defined('OPENSSL_KEYTYPE_ED25519')) {
             $pkParts = [];
             if (\preg_match('/BEGIN PUBLIC KEY\-+(?:\s|\n|\r)+([^\-]+)(?:\s|\n|\r)*\-+END PUBLIC KEY/i', $credentialPublicKey, $pkParts)) {
                 $rawPk = \base64_decode($pkParts[1]);
@@ -685,7 +685,7 @@ class WebAuthn {
                 // 30        = der sequence
                 // 2a        = length 42 byte
                 // 30        = der sequence
-                // 05        = lenght 5 byte
+                // 05        = length 5 byte
                 // 06        = der OID
                 // 03        = OID length 3 byte
                 // 2b 65 70  = OID 1.3.101.112 curveEd25519 (EdDSA 25519 signature algorithm)
@@ -709,6 +709,17 @@ class WebAuthn {
             throw new WebAuthnException('public key invalid', WebAuthnException::INVALID_PUBLIC_KEY);
         }
 
-        return \openssl_verify($dataToVerify, $signature, $publicKey, OPENSSL_ALGO_SHA256) === 1;
+        $algo = OPENSSL_ALGO_SHA256;
+
+        if(defined('OPENSSL_KEYTYPE_ED25519')) {
+            $publicKeyDetails = openssl_pkey_get_details($publicKey);
+
+            if($publicKeyDetails && $publicKeyDetails['type'] === OPENSSL_KEYTYPE_ED25519) {
+                // algorithm 0 is used because EdDSA has a built-in hash
+                $algo = 0;
+            }
+        }
+
+        return \openssl_verify($dataToVerify, $signature, $publicKey, $algo) === 1;
     }
 }

--- a/src/WebAuthn.php
+++ b/src/WebAuthn.php
@@ -676,7 +676,7 @@ class WebAuthn {
      */
     private function _verifySignature($dataToVerify, $signature, $credentialPublicKey) {
 
-        // Use Sodium to verify EdDSA 25519 as its not yet supported by openssl
+        // Use Sodium to verify EdDSA 25519 if it's not supported by openssl
         if (\function_exists('sodium_crypto_sign_verify_detached') && !defined('OPENSSL_KEYTYPE_ED25519')) {
             $pkParts = [];
             if (\preg_match('/BEGIN PUBLIC KEY\-+(?:\s|\n|\r)+([^\-]+)(?:\s|\n|\r)*\-+END PUBLIC KEY/i', $credentialPublicKey, $pkParts)) {


### PR DESCRIPTION
PHP 8.4 added ed25519 support in OpenSSL:
https://www.php.net/manual/en/migration84.new-features.php#migration84.new-features.openssl

`openssl_get_curve_names()` does not return `ed25519`, so the previous curve-based check did not work.

I changed the detection to check if `OPENSSL_KEYTYPE_ED25519` is defined instead.

There was also an issue in the verify logic: for Ed25519, `openssl_verify()` must use algorithm `0`, not `OPENSSL_ALGO_SHA256`.

At the moment, I am using `openssl_pkey_get_details()` to determine the key type. I am not sure whether there is a better way to detect this without calling `openssl_pkey_get_details()`, but this works for now.
